### PR TITLE
Upgrade gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Projekt nesmí být na cestě, která obsahuje diakritiku

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath("com.android.tools.build:gradle:7.1.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Aby bylo možné používat novější JDKčka, je potřeba podle této gradle tabulky https://docs.gradle.org/current/userguide/compatibility.html updatnout gradle na verzi 7.

Nemělo by být potřeba si lokálně updatovat verzi JDKčka.

Taky jsem zjistil, že projekt nesmí mít v cestě na file systému non-ASCI znaky, tak jsem to zadal do README